### PR TITLE
SLM: add BM25 retriever, optional T5 generator, tests, and README steps

### DIFF
--- a/bot-combat-dataset/README.md
+++ b/bot-combat-dataset/README.md
@@ -177,7 +177,26 @@ One-shot question:
 ```bash
 python -m bot_combat_dataset.cli chat --data data/bot_combat_dataset.xlsx -q "Show finals winners for the 2018 season"
 ```
-How it works: a compact TF‑IDF retriever indexes rows from `fights` and `bots`. At query time, the top‑k rows are retrieved and a small template synthesizes an answer. No remote calls, no GPU, no LLM APIs.
+How it works (SLM-style):
+- Default retriever is TF‑IDF; you can switch to BM25 for better sparse matching.
+- Answer synthesis is template-based by default; optionally enable a tiny `t5-small` generator if you have internet and want slightly more fluent answers.
+
+To use BM25 and/or T5 generation in code:
+```python
+from bot_combat_dataset.chat.agent import RetrievalQABot, RetrievalQAConfig
+# tables = build_dataframes(...)
+cfg = RetrievalQAConfig(retriever="bm25", generator="template")
+agent = RetrievalQABot(tables, cfg)
+print(agent.answer("Who defeated Tombstone? ")['answer'])
+```
+
+If you want T5 generation:
+```python
+from bot_combat_dataset.chat.agent import RetrievalQABot, RetrievalQAConfig
+cfg = RetrievalQAConfig(retriever="bm25", generator="t5", t5_model_name="t5-small")
+agent = RetrievalQABot(tables, cfg)
+print(agent.answer("Summarize the finals result.")["answer"])
+```
 
 ## Notes on scraping ethically
 - Check and respect each site’s Terms of Use and robots.txt
@@ -189,6 +208,28 @@ How it works: a compact TF‑IDF retriever indexes rows from `fights` and `bots`
 - Python 3.13 builds: If `pandas` or other packages attempt to build from source and fail, use Python 3.11/3.12.
 - PATH warnings after user‑site install: add `~/.local/bin` to your PATH.
 - Fandom page not found (404): season page slugs can change; search the wiki and update the URL accordingly.
+
+## Testing
+Install test deps (already in `requirements.txt`) and run:
+```bash
+cd bot-combat-dataset
+./scripts/setup_venv.sh
+source .venv/bin/activate  # if created
+pytest
+```
+
+Run a single file or test for quick feedback:
+```bash
+pytest tests/test_robotwars_scraper.py::test_parse_fights_section_mixed_headers -q
+pytest tests/test_chat_agent.py -q
+pytest tests/test_chat_agent_bm25.py -q
+```
+
+Smoke-test the CLI end-to-end (demo):
+```bash
+python -m bot_combat_dataset.cli build --demo --excel data/bot_combat_dataset.xlsx --parquet data/processed
+python -m bot_combat_dataset.cli chat --data data/bot_combat_dataset.xlsx -q "Who won the finals?"
+```
 
 ## Publishing as a standalone GitHub repo (optional)
 If this project lives within a monorepo and you want to publish just `bot-combat-dataset/` as its own repository, you can use a subtree split:

--- a/bot-combat-dataset/bot_combat_dataset/chat/agent.py
+++ b/bot-combat-dataset/bot_combat_dataset/chat/agent.py
@@ -1,16 +1,28 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 
 import pandas as pd
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
+try:
+    from rank_bm25 import BM25Okapi  # lightweight BM25 implementation
+except Exception:  # pragma: no cover - optional during import time
+    BM25Okapi = None  # type: ignore
 
 
 @dataclass
 class RetrievalQAConfig:
     max_contexts: int = 8
+    retriever: str = "tfidf"  # "tfidf" | "bm25"
+    # BM25 parameters (used when retriever == "bm25")
+    bm25_k1: float = 1.5
+    bm25_b: float = 0.75
+    # Generator options (answer synthesis)
+    generator: str = "template"  # "template" | "t5"
+    t5_model_name: str = "t5-small"  # used if generator == "t5"
+    max_answer_tokens: int = 64
 
 
 class RetrievalQABot:
@@ -19,8 +31,12 @@ class RetrievalQABot:
         self.tables = tables
         self.documents: List[str] = []
         self.doc_meta: List[Dict[str, Any]] = []
-        self._vectorizer = TfidfVectorizer(stop_words="english")
+        # TF-IDF state
+        self._vectorizer: Optional[TfidfVectorizer] = None
         self._matrix = None
+        # BM25 state
+        self._bm25: Optional[BM25Okapi] = None
+        self._bm25_tokens: List[List[str]] = []
         self._build_knowledge_base()
 
     def _build_knowledge_base(self) -> None:
@@ -73,18 +89,65 @@ class RetrievalQABot:
         self.doc_meta = meta
         if not docs:
             self._matrix = None
+            self._bm25 = None
             return
-        self._matrix = self._vectorizer.fit_transform(docs)
+
+        # Build retriever index according to configuration
+        if self.config.retriever == "bm25" and BM25Okapi is not None:
+            # Simple whitespace tokenization with lower-casing
+            self._bm25_tokens = [self._tokenize_for_bm25(text) for text in docs]
+            self._bm25 = BM25Okapi(self._bm25_tokens, k1=self.config.bm25_k1, b=self.config.bm25_b)
+            self._vectorizer = None
+            self._matrix = None
+        else:
+            # Default to TF-IDF
+            self._vectorizer = TfidfVectorizer(stop_words="english")
+            self._matrix = self._vectorizer.fit_transform(docs)
+            self._bm25 = None
 
     def answer(self, question: str) -> Dict[str, Any]:
-        if self._matrix is None or not self.documents:
+        if not self.documents:
             return {"answer": "No knowledge loaded.", "contexts": []}
+
+        contexts = self._retrieve(question)
+        answer_text = self._generate_answer(question, contexts)
+        return {"answer": answer_text, "contexts": contexts}
+
+    # --- Retrieval ---
+    def _retrieve(self, question: str) -> List[Dict[str, Any]]:
+        if self.config.retriever == "bm25" and self._bm25 is not None:
+            query_tokens = self._tokenize_for_bm25(question)
+            scores = self._bm25.get_scores(query_tokens)
+            order = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)
+            top = order[: self.config.max_contexts]
+            contexts = [
+                self.doc_meta[i] | {"text": self.documents[i], "score": float(scores[i])}
+                for i in top
+            ]
+            return contexts
+
+        # TF-IDF fallback
+        if self._vectorizer is None or self._matrix is None:
+            return []
         q_vec = self._vectorizer.transform([question])
         sims = cosine_similarity(q_vec, self._matrix)[0]
         ranked = sims.argsort()[::-1][: self.config.max_contexts]
-        contexts = [self.doc_meta[i] | {"text": self.documents[i], "score": float(sims[i])} for i in ranked]
+        return [self.doc_meta[i] | {"text": self.documents[i], "score": float(sims[i])} for i in ranked]
 
-        # Simple template-based synthesis
+    @staticmethod
+    def _tokenize_for_bm25(text: str) -> List[str]:
+        return [t for t in (text or "").lower().split() if t]
+
+    # --- Generation ---
+    def _generate_answer(self, question: str, contexts: List[Dict[str, Any]]) -> str:
+        if self.config.generator == "t5":
+            generated = self._try_generate_with_t5(question, contexts)
+            if generated:
+                return generated
+        # Fallback to template
+        return self._template_answer(contexts)
+
+    def _template_answer(self, contexts: List[Dict[str, Any]]) -> str:
         best = contexts[0] if contexts else None
         if best and best.get("table") == "fights":
             row = best["row"]
@@ -92,8 +155,37 @@ class RetrievalQABot:
             blue = row.get("blue_bot_name")
             red = row.get("red_bot_name")
             method = row.get("method")
-            summary = f"{winner} defeated {blue if winner!=blue else red} via {method}." if winner else "Match result unknown."
-        else:
-            summary = best["text"] if best else "No relevant context found."
+            return (
+                f"{winner} defeated {blue if winner != blue else red} via {method}."
+                if winner
+                else "Match result unknown."
+            )
+        return best["text"] if best else "No relevant context found."
 
-        return {"answer": summary, "contexts": contexts}
+    def _try_generate_with_t5(self, question: str, contexts: List[Dict[str, Any]]) -> Optional[str]:
+        try:
+            from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
+        except Exception:
+            return None
+
+        if not contexts:
+            return None
+
+        # Build a compact prompt from top contexts
+        top_ctx_text = "\n".join(ctx["text"] for ctx in contexts[:3])
+        prompt = (
+            "You are a concise Q&A bot about robot combat matches.\n"
+            "Answer the question using the provided context.\n\n"
+            f"Context:\n{top_ctx_text}\n\nQuestion: {question}\nAnswer:"
+        )
+
+        try:
+            tok = AutoTokenizer.from_pretrained(self.config.t5_model_name)
+            model = AutoModelForSeq2SeqLM.from_pretrained(self.config.t5_model_name)
+            input_ids = tok(prompt, return_tensors="pt", truncation=True).input_ids
+            out = model.generate(input_ids, max_new_tokens=self.config.max_answer_tokens)
+            text = tok.decode(out[0], skip_special_tokens=True)
+            return text.strip()
+        except Exception:
+            # If model loading/generation fails (no internet, missing deps), fallback
+            return None

--- a/bot-combat-dataset/requirements.txt
+++ b/bot-combat-dataset/requirements.txt
@@ -10,3 +10,6 @@ scikit-learn==1.5.2
 tqdm==4.66.5
 tenacity==8.5.0
 pytest==8.3.3
+rank-bm25==0.2.2
+transformers==4.44.2
+torch>=2.0.0; platform_system != 'Windows'

--- a/bot-combat-dataset/tests/test_chat_agent_bm25.py
+++ b/bot-combat-dataset/tests/test_chat_agent_bm25.py
@@ -1,0 +1,40 @@
+from bot_combat_dataset.chat.agent import RetrievalQABot, RetrievalQAConfig
+from bot_combat_dataset.normalization import build_dataframes
+from bot_combat_dataset.schemas import Bot, Fight, Event
+
+
+def test_bm25_retrieval_finds_correct_fight():
+    bots = [
+        Bot(bot_id="razer", name="Razer"),
+        Bot(bot_id="chaos-2", name="Chaos 2"),
+    ]
+    events = [
+        Event(event_id="rw-7", name="Robot Wars Series 7", series="Robot Wars", season="Series 7"),
+    ]
+    fights = [
+        Fight(
+            fight_id="semi-razer-chaos2",
+            event_id="rw-7",
+            series="Robot Wars",
+            season="Series 7",
+            round_name="Semi",
+            blue_bot_id="razer",
+            red_bot_id="chaos-2",
+            blue_bot_name="Razer",
+            red_bot_name="Chaos 2",
+            winner_bot_id="chaos-2",
+            winner_bot_name="Chaos 2",
+            method="UD",
+            duration="3:00",
+            referee_decision=True,
+            notes="Judges' decision",
+            source_url="http://example.com",
+        )
+    ]
+
+    tables = build_dataframes(bots=bots, fights=fights, events=events)
+    cfg = RetrievalQAConfig(retriever="bm25")
+    agent = RetrievalQABot(tables, cfg)
+
+    result = agent.answer("Who won the semi between Razer and Chaos 2?")
+    assert "Chaos 2" in result["answer"]


### PR DESCRIPTION
- RetrievalQABot now supports retriever="bm25" alongside TF-IDF
- Optional generation via transformers T5-small with graceful fallback
- Added pytest for BM25 path, updated docs with step-by-step testing commands
- Added dependencies: rank-bm25, transformers, torch (linux-only)